### PR TITLE
fix: log() to stderr, suppress git clone output in produce-local.sh

### DIFF
--- a/tools/produce-local.sh
+++ b/tools/produce-local.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 INPUT_VER="${1:-}"
 
-log() { printf '[produce-local] %s\n' "$*"; }
+log() { printf '[produce-local] %s\n' "$*"; } >&2;
 die() {
 	printf '[produce-local] ERROR: %s\n' "$*" >&2
 	exit 1
@@ -66,7 +66,7 @@ resolve_loader_repo() {
 		return 1
 	fi
 	rm -rf "$LOADER_VENDOR"
-	git clone --depth 1 "$LOADER_URL" "$LOADER_VENDOR" 2>&1 || return 1
+	git clone --depth 1 "$LOADER_URL" "$LOADER_VENDOR" >/dev/null 2>&1 || return 1
 	if [[ ! -f "$LOADER_VENDOR/build.py" ]]; then
 		log "warning: cloned repo missing build.py, cleaning up"
 		rm -rf "$LOADER_VENDOR"


### PR DESCRIPTION
## Problem
`produce-local.sh` had two stdout pollution bugs that broke `LOADER_REPO` resolution:

1. `log()` output to stdout -- captured by `$(resolve_loader_repo)`, polluting the path variable
2. `git clone 2>&1` -- merges stderr into stdout, also captured

Result: `cd "$LOADER_REPO"` failed with mangled path containing log output.

## Fix
- `log()` redirects to stderr
- `git clone` suppressed with `>/dev/null 2>&1`

## Related
- **Main bug fix:** https://github.com/Hope2333/bun-termux-loader/pull/1 (`wrapper.c`: `/proc/self/exe` -> `readlink()`)
- **Issue:** https://github.com/Hope2333/opencode-termux/issues/3

Both fixes together resolve `error: read failed` on OnePlus 12 (Android/Termux).

## Tested
Builds successfully on Termux/aarch64 (OnePlus 12). Combined with the bun-termux-loader PR, `opencode --version` returns `1.15.10`.