### PR TITLE
Fix: Replace incorrect apt install with dpkg -i for local deb package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ apt update
 apt install -y glibc openssl-glibc
 
 # Then install opencode
-apt install -y /path/to/opencode_<version>_aarch64.deb
+dpkg -i /path/to/opencode_<version>_aarch64.deb
 ```
 
 ### Path B: pacman (secondary)
@@ -122,7 +122,7 @@ See `docs/native-android-research.md` for full research details.
 apt install -y glibc-repo
 apt update
 apt install -y glibc openssl-glibc
-apt install -y /path/to/opencode_<version>_aarch64.deb
+dpkg -i /path/to/opencode_<version>_aarch64.deb
 
 # Path B: pacman
 pacman -Syu


### PR DESCRIPTION
### Overview

This PR replaces the incorrect use of apt install -y for local .deb packages with the proper dpkg -i command. Problem using apt install -y directly on local paths fails on certain environments. I have tested this multiple times on my local machine (Termux on Android), and the current implementation does not work as intended for local Debian packages.

**Solution**: 
Change the installation command to use dpkg -i instead.

Target command: `dpkg -i /path/location/opencode_1.17.7_aarch64.deb` I have successfully implemented and tested this approach in my own project using the following configuration:

`export FZF_DEFAULT_OPTS=(--bind="one:execute(tmpfile=\$(mktemp) && wget -O \"\$tmpfile\" {3} && dpkg -i \"\$tmpfile\" && rm -f \"\$tmpfile\" && exit)+abort" )`

### References
Source Implementation:
 [luisadha/nene](https://raw.githubusercontent.com/luisadha/nene/refs/heads/main/bin/nene)